### PR TITLE
LPS-41279 - Chat portlet user avatar is too big in IE

### DIFF
--- a/portlets/chat-portlet/docroot/css/main.css
+++ b/portlets/chat-portlet/docroot/css/main.css
@@ -476,6 +476,10 @@ pre.chat-height-monitor {
 		width: 202px;
 	}
 
+	.panel-icon {
+		max-width: 48px;
+	}
+
 	.panel-output {
 		position: relative;
 	}


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-41279
