### PR TITLE
LPS-49177 - default-web-content-hook Carousel display issues

### DIFF
--- a/hooks/default-web-content-hook/docroot/WEB-INF/src/resources/templates/multiple_item_carousel.vm
+++ b/hooks/default-web-content-hook/docroot/WEB-INF/src/resources/templates/multiple_item_carousel.vm
@@ -8,7 +8,7 @@
 		width: $width.getData()px;
 	}
 
-	#$contentClass .carousel-item {
+	#$contentClass .image-viewer-base-node-content {
 		height: $height.getData()px;
 		overflow: hidden;
 		width: $width.getData()px;
@@ -19,7 +19,7 @@
 
 <div id="$contentClass">
 	#foreach ($item in $content.getSiblings())
-		<div class="carousel-item">
+		<div class="image-viewer-base-node-content">
 			$item.getData()
 		</div>
 	#end


### PR DESCRIPTION
Hi Jon,

Attached is an update for https://issues.liferay.com/browse/LPS-49177.

These changes update the markup to now work with the updated carousel.

I must have forgotten to send this fix when I sent the fix for the image-viewer/carousel.  Sorry about that.

Please let me know if there are any issues.

Thanks!
