### PR TITLE
LPS-40606 OpenSocial Gadget Publisher updated to use <aui:button>

### DIFF
--- a/portlets/opensocial-portlet/docroot/admin/view.jsp
+++ b/portlets/opensocial-portlet/docroot/admin/view.jsp
@@ -61,12 +61,21 @@ PortletURL portletURL = renderResponse.createRenderURL();
 	<div>
 		<c:if test="<%= GadgetPermission.contains(permissionChecker, themeDisplay.getScopeGroupId(), ActionKeys.PUBLISH_GADGET) %>">
 			<span>
-				<input onClick="location.href = '<portlet:renderURL><portlet:param name="mvcPath" value="/admin/edit_gadget.jsp" /><portlet:param name="redirect" value="<%= currentURL %>" /></portlet:renderURL>';" type="button" value="<liferay-ui:message key="publish-gadget" />" />
+				<portlet:renderURL var="publishGadget" >
+					<portlet:param name="mvcPath" value="/admin/edit_gadget.jsp" />
+					<portlet:param name="redirect" value="<%= currentURL %>"/>
+				</portlet:renderURL>
+
+				<aui:button onClick="<%= publishGadget %>" type="button" value="publish-gadget" />
 			</span>
 		</c:if>
 
 		<span>
-			<input onClick="location.href = '<portlet:actionURL name="refreshGadgets"><portlet:param name="redirect" value="<%= currentURL %>" /></portlet:actionURL>';" type="button" value="<liferay-ui:message key="refresh-gadgets" />" />
+			<portlet:actionURL name="refreshGadgets" var="refreshGadgets" >
+				<portlet:param name="redirect" value="<%= currentURL %>" />
+			</portlet:actionURL>
+
+			<aui:button onClick="<%= refreshGadgets %>" type="button" value="refresh-gadgets" />
 		</span>
 	</div>
 


### PR DESCRIPTION
Jira ticket: https://issues.liferay.com/browse/LPS-40606
Alternate solution to: https://github.com/noellekimiko/liferay-plugins/pull/6
- Same fix for 6.2.x: https://github.com/jonmak08/liferay-plugins/pull/226https://github.com/jonmak08/liferay-plugins/pull/226
- Tested with a bundle built from https://github.com/liferay/liferay-portal/commit/5a3aa06f217d60005409fa4dc86921623f40dfaf
- Tested in Chrome, Firefox, and IE 8 - 11
- By changing the `<input>` tag to an `<aui:button`> one, the buttons are now styled with bootstrap and are easier to maintain.
- Also, buttons are now responsive to narrower page widths in all browsers except IE 8 
  ![responsive buttons after](https://cloud.githubusercontent.com/assets/6542536/5056060/2a14185a-6c25-11e4-9607-adebd1e62182.png)

**Potential Problems**
- `<aui:button>` results in an `<a>` tag in all browsers, instead of a `<button>` one as expected. This is in the taglib, not this bugfix, but it is a bit unexpected.
