### PR TITLE
[TECHNICAL SUPPORT] LPS-61654 youtube portlet does not work with IE nor on mobile phones

### DIFF
--- a/portlets/youtube-portlet/docroot/configuration.jsp
+++ b/portlets/youtube-portlet/docroot/configuration.jsp
@@ -97,7 +97,7 @@
 		};
 		var width = parseInt(widthNode.val(), 10) || 0;
 
-		var playerOptionsCompiled = [swfURL + id];
+		var playerOptionsCompiled = ['wmode=transparent'];
 		var ratio = Math.min(maxWidth / width, 1);
 
 		height = Math.floor(height * ratio);
@@ -110,17 +110,7 @@
 		}
 
 		if (id) {
-			previewNode.setContent(['<a href="', watchURL, id, '" rel="external" title="watch-this-video-at-youtube"><img alt="youtube-video" height="100%" src="', imageURL.replace('<%= id %>', id), '" width="100%" /></a>'].join(''));
-
-			new A.SWF(
-				{
-					boundingBox: previewNode,
-					height: height,
-					url: playerOptionsCompiled.join('&'),
-					width: width,
-					version: 0
-				}
-			).render();
+			previewNode.setContent(['<iframe src="', embedURL, id, '?', playerOptionsCompiled.join('&'), '" frameborder="0" height="<%= height %>" width="<%= width %>" wmode="Opaque"></iframe>'].join(''));
 		}
 		else {
 			previewNode.setStyles(
@@ -172,8 +162,8 @@
 	var urlNode = A.one('#<portlet:namespace />url');
 	var widthNode = A.one('#<portlet:namespace />width');
 
+	var embedURL = '<%= embedURL %>';
 	var imageURL = '<%= imageURL %>';
-	var swfURL = '<%= swfURL %>';
 	var watchURL = '<%= watchURL %>';
 
 	A.on(

--- a/portlets/youtube-portlet/docroot/init.jsp
+++ b/portlets/youtube-portlet/docroot/init.jsp
@@ -50,7 +50,7 @@ String id = url.replaceAll("^.*?v=([a-zA-Z0-9_-]+).*$", "$1");
 
 String presetSize = width + "x" + height;
 
+String embedURL = HttpUtil.getProtocol(request) + "://www.youtube.com/embed/";
 String imageURL = HttpUtil.getProtocol(request) + "://img.youtube.com/vi/" + id + "/0.jpg";
-String swfURL = HttpUtil.getProtocol(request) + "://www.youtube.com/v/";
 String watchURL = HttpUtil.getProtocol(request) + "://www.youtube.com/watch?v=";
 %>

--- a/portlets/youtube-portlet/docroot/view.jsp
+++ b/portlets/youtube-portlet/docroot/view.jsp
@@ -22,6 +22,10 @@
 		<%
 		StringBundler sb = new StringBundler();
 
+		// wmode=transparent and wmode=Opaque may need for IE z-index issue (iframe covers the portlet's configuration menu in IE)
+		sb.append("?wmode=transparent");
+
+
 		if (autoplay) {
 			sb.append("&amp;autoplay=1");
 		}
@@ -52,19 +56,13 @@
 		}
 		%>
 
-		<liferay-ui:flash
-			allowScriptAccess="true"
-			height="<%= height %>"
-			movie="<%= swfURL + id + sb.toString() %>"
-			width="<%= width %>"
-			wmode="opaque"
-		>
-			<c:if test="<%= showThumbnail %>">
-				<aui:a href="<%= watchURL + id %>" rel="external" title='<%= HtmlUtil.escapeAttribute(LanguageUtil.get(request, "watch-this-video-at-youtube")) %>'>
-					<img alt="<liferay-ui:message escapeAttribute="<%= true %>" key="youtube-video" />" height="<%= height %>" src="<%= imageURL %>" width="<%= width %>" />
-				</aui:a>
-			</c:if>
-		</liferay-ui:flash>
+		<c:if test="<%= showThumbnail %>">
+			<aui:a href="<%= watchURL + id %>" rel="external" title='<%= HtmlUtil.escapeAttribute(LanguageUtil.get(request, "watch-this-video-at-youtube")) %>'>
+				<img alt="<liferay-ui:message escapeAttribute="<%= true %>" key="youtube-video" />" height="<%= height %>" src="<%= imageURL %>" width="<%= width %>" />
+			</aui:a>
+		</c:if>
+
+		<iframe width="<%= width %>" height="<%= height %>" src="<%= embedURL + id + sb.toString() %>" frameborder="0" wmode="Opaque" allowfullscreen/></iframe>
 	</c:when>
 	<c:otherwise>
 		<liferay-util:include page="/html/portal/portlet_not_setup.jsp" />


### PR DESCRIPTION
Hi Jon,

This is the second pull about Youtube portlet but this was the first issue which customer opened.
Fortunately, that bugs which are/will fixed are independent of each other.

The main thing is ie11 and mobile browsers don't display YouTube videos in our YouTube portlet at all. It can be an ie bug easily(it is) but the time has come to forget flash in YouTube portlet and use iframe instead.

Peter Borkuti made a solution for this issue which works correctly.

Please see LPS ticket for the detailed information.

What is your opinion?

Thanks for your review,
 Zsaga